### PR TITLE
Template slides & resolution plots

### DIFF
--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/L1TrackNtuplePlot.C
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/L1TrackNtuplePlot.C
@@ -1659,6 +1659,42 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   // resoultion vs pt
   // ----------------------------------------------------------------------------------------------------------
 
+  h2_resVsPt_pt_90->SetMinimum(0);
+  h2_resVsPt_pt_90->SetMarkerStyle(20);
+  h2_resVsPt_pt_90->Draw("p");
+  c.SaveAs(DIR+type+"_resVsPt_pt_90.eps");
+  c.SaveAs(DIR+type+"_resVsPt_pt_90.png");
+
+  h2_resVsPt_ptRel_90->SetMinimum(0);
+  h2_resVsPt_ptRel_90->SetMarkerStyle(20);
+  h2_resVsPt_ptRel_90->Draw("p");
+  c.SaveAs(DIR+type+"_resVsPt_ptRel_90.eps");
+  c.SaveAs(DIR+type+"_resVsPt_ptRel_90.png");
+
+  h2_resVsPt_z0_90->SetMinimum(0);
+  h2_resVsPt_z0_90->SetMarkerStyle(20);
+  h2_resVsPt_z0_90->Draw("p");
+  c.SaveAs(DIR+type+"_resVsPt_z0_90.eps");
+  c.SaveAs(DIR+type+"_resVsPt_z0_90.png");
+
+  h2_resVsPt_phi_90->SetMinimum(0);
+  h2_resVsPt_phi_90->SetMarkerStyle(20);
+  h2_resVsPt_phi_90->Draw("p");
+  c.SaveAs(DIR+type+"_resVsPt_phi_90.eps");
+  c.SaveAs(DIR+type+"_resVsPt_phi_90.png");
+
+  h2_resVsPt_eta_90->SetMinimum(0);
+  h2_resVsPt_eta_90->SetMarkerStyle(20);
+  h2_resVsPt_eta_90->Draw("p");
+  c.SaveAs(DIR+type+"_resVsPt_eta_90.eps");
+  c.SaveAs(DIR+type+"_resVsPt_eta_90.png");
+
+  h2_resVsPt_phi_90->SetMinimum(0);
+  h2_resVsPt_d0_90->SetMarkerStyle(20);
+  h2_resVsPt_d0_90->Draw("p");
+  c.SaveAs(DIR+type+"_resVsPt_d0_90.eps");
+  c.SaveAs(DIR+type+"_resVsPt_d0_90.png");
+
   if (doDetailedPlots) {
     h2_resVsPt_eta->Write();
 
@@ -1693,6 +1729,95 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   // ----------------------------------------------------------------------------------------------------------
   // resolution vs eta
   // ----------------------------------------------------------------------------------------------------------
+
+  h2_resVsEta_eta_90->SetMinimum(0);
+  h2_resVsEta_eta_90->SetMarkerStyle(20);
+  h2_resVsEta_eta_90->Draw("p");
+  c.SaveAs(DIR+type+"_resVsEta_eta_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_eta_90.png");
+
+  h2_resVsEta_eta_L_90->Draw();
+  sprintf(ctxt,"p_{T} < 8 GeV");
+  mySmallText(0.22,0.82,1,ctxt);
+  c.SaveAs(DIR+type+"_resVsEta_eta_L_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_eta_L_90.png");
+  
+  h2_resVsEta_eta_H_90->Draw();
+  sprintf(ctxt,"p_{T} > 8 GeV");
+  mySmallText(0.22,0.82,1,ctxt);
+  c.SaveAs(DIR+type+"_resVsEta_eta_H_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_eta_H_90.png");
+
+  h2_resVsEta_z0_90->SetMinimum(0);
+  h2_resVsEta_z0_90->SetMarkerStyle(20);
+  h2_resVsEta_z0_90->Draw("p");
+  c.SaveAs(DIR+type+"_resVsEta_z0_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_z0_90.png");
+
+  h2_resVsEta_z0_L_90->Draw();
+  sprintf(ctxt,"p_{T} < 8 GeV");
+  mySmallText(0.22,0.82,1,ctxt);
+  c.SaveAs(DIR+type+"_resVsEta_z0_L_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_z0_L_90.png");
+  
+  h2_resVsEta_z0_H_90->Draw();
+  sprintf(ctxt,"p_{T} > 8 GeV");
+  mySmallText(0.22,0.82,1,ctxt);
+  c.SaveAs(DIR+type+"_resVsEta_z0_H_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_z0_H_90.png");
+
+  h2_resVsEta_d0_90->Draw();
+  c.SaveAs(DIR+type+"_resVsEta_d0_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_d0_90.png");
+
+  h2_resVsEta_d0_L_90->Draw();
+  sprintf(ctxt,"p_{T} < 8 GeV");
+  mySmallText(0.22,0.82,1,ctxt);
+  c.SaveAs(DIR+type+"_resVsEta_d0_L_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_d0_L_90.png");
+
+  h2_resVsEta_d0_H_90->Draw();
+  sprintf(ctxt,"p_{T} > 8 GeV");
+  mySmallText(0.22,0.82,1,ctxt);
+  c.SaveAs(DIR+type+"_resVsEta_d0_H_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_d0_H_90.png");
+
+  h2_resVsEta_phi_90->SetMinimum(0);
+  h2_resVsEta_phi_90->SetMarkerStyle(20);
+  h2_resVsEta_phi_90->Draw("p");
+  c.SaveAs(DIR+type+"_resVsEta_phi_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_phi_90.png");
+
+  h2_resVsEta_phi_L_90->Draw();
+  sprintf(ctxt,"p_{T} < 8 GeV");
+  mySmallText(0.22,0.82,1,ctxt);
+  c.SaveAs(DIR+type+"_resVsEta_phi_L_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_phi_L_90.png");
+
+  h2_resVsEta_phi_H_90->Draw();
+  sprintf(ctxt,"p_{T} > 8 GeV");
+  mySmallText(0.22,0.82,1,ctxt);
+  c.SaveAs(DIR+type+"_resVsEta_phi_H_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_phi_H_90.png");
+
+
+  h2_resVsEta_ptRel_90->SetMinimum(0);
+  h2_resVsEta_ptRel_90->SetMarkerStyle(20);
+  h2_resVsEta_ptRel_90->Draw("p");
+  c.SaveAs(DIR+type+"_resVsEta_ptRel_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_ptRel_90.png");
+
+  h2_resVsEta_ptRel_L_90->Draw();
+  sprintf(ctxt,"p_{T} < 8 GeV");
+  mySmallText(0.22,0.82,1,ctxt);
+  c.SaveAs(DIR+type+"_resVsEta_ptRel_L_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_ptRel_L_90.png");
+
+  h2_resVsEta_ptRel_H_90->Draw();
+  sprintf(ctxt,"p_{T} > 8 GeV");
+  mySmallText(0.22,0.82,1,ctxt);
+  c.SaveAs(DIR+type+"_resVsEta_ptRel_H_90.eps");
+  c.SaveAs(DIR+type+"_resVsEta_ptRel_H_90.png");
 
   if (doDetailedPlots) {
     h2_resVsEta_eta->Write();

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/L1TrackNtuplePlot.C
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/L1TrackNtuplePlot.C
@@ -342,6 +342,13 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   TH1F* h_absResVsPt_eta[nRANGE];
   TH1F* h_absResVsPt_d0[nRANGE];
 
+  TH1F* h_absResVsPt_pt_L[nRANGE];
+  TH1F* h_absResVsPt_ptRel_L[nRANGE];
+  TH1F* h_absResVsPt_z0_L[nRANGE];
+  TH1F* h_absResVsPt_phi_L[nRANGE];
+  TH1F* h_absResVsPt_eta_L[nRANGE];
+  TH1F* h_absResVsPt_d0_L[nRANGE];
+
   for (int i=0; i<nRANGE; i++) {
     h_absResVsPt_pt[i]    = new TH1F("absResVsPt_pt_"+ptrange[i],   ";p_{T} residual (L1 - sim) [GeV]; L1 tracks / 0.1",   nBinsPtRes,    0, maxPtRes);
     h_absResVsPt_ptRel[i] = new TH1F("absResVsPt_ptRel_"+ptrange[i],";p_{T} residual (L1 - sim) / p_{T}; L1 tracks / 0.02",nBinsPtRelRes, 0, maxPtRelRes);
@@ -349,6 +356,18 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
     h_absResVsPt_phi[i]   = new TH1F("absResVsPt_phi_"+ptrange[i],  ";#phi residual (L1 - sim) [GeV]; L1 tracks / 0.1",    nBinsPhiRes,   0, maxPhiRes);
     h_absResVsPt_eta[i]   = new TH1F("absResVsPt_eta_"+ptrange[i],  ";#eta residual (L1 - sim) [GeV]; L1 tracks / 0.1",    nBinsEtaRes,   0, maxEtaRes);
     h_absResVsPt_d0[i]    = new TH1F("absResVsPt_d0_"+ptrange[i],   ";d_{0}residual (L1 - sim) [GeV]; L1 tracks / 0.1",    100,           0, 0.02);
+  }
+
+  const int nRANGE_L = 10;
+  TString ptrange_L[nRANGE] = {"3-3.5", "3.5-4", "4-4.5", "4.5-5", "5-5.5", "5.5-6", "6-6.5", "6.5-7", "7-7.5", "7.5-8" };
+
+  for (int i=0; i<nRANGE; i++) {
+    h_absResVsPt_pt_L[i]    = new TH1F("absResVsPt_L_pt_"+ptrange_L[i],   ";p_{T} residual (L1 - sim) [GeV]; L1 tracks / 0.1",   nBinsPtRes,    0, maxPtRes);
+    h_absResVsPt_ptRel_L[i] = new TH1F("absResVsPt_L_ptRel_"+ptrange_L[i],";p_{T} residual (L1 - sim) / p_{T}; L1 tracks / 0.02",nBinsPtRelRes, 0, maxPtRelRes);
+    h_absResVsPt_z0_L[i]    = new TH1F("absResVsPt_L_z0_"+ptrange_L[i],   ";z_{0} residual (L1 - sim) [GeV]; L1 tracks / 0.1",   nBinsZ0Res,    0, maxZ0Res);
+    h_absResVsPt_phi_L[i]   = new TH1F("absResVsPt_L_phi_"+ptrange_L[i],  ";#phi residual (L1 - sim) [GeV]; L1 tracks / 0.1",    nBinsPhiRes,   0, maxPhiRes);
+    h_absResVsPt_eta_L[i]   = new TH1F("absResVsPt_L_eta_"+ptrange_L[i],  ";#eta residual (L1 - sim) [GeV]; L1 tracks / 0.1",    nBinsEtaRes,   0, maxEtaRes);
+    h_absResVsPt_d0_L[i]    = new TH1F("absResVsPt_L_d0_"+ptrange_L[i],   ";d_{0}residual (L1 - sim) [GeV]; L1 tracks / 0.1",    100,           0, 0.02);
   }
 
   // resolution vs. eta histograms
@@ -910,6 +929,15 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
 	}
       }
       
+  for (int im=6; im<nRANGE_L+6; im++) {
+    if ( (tp_pt->at(it) > (float)im*0.5 ) && (tp_pt->at(it) <= (float)im*0.5+0.5) ) {
+            h_absResVsPt_pt_L[im-6]   ->Fill( fabs( matchtrk_pt->at(it)  - tp_pt->at(it) ));
+            h_absResVsPt_ptRel_L[im-6]->Fill( fabs( (matchtrk_pt->at(it) - tp_pt->at(it)) )/tp_pt->at(it) );
+            h_absResVsPt_z0_L[im-6]   ->Fill( fabs( matchtrk_z0->at(it)  - tp_z0->at(it) ) );
+            h_absResVsPt_phi_L[im-6]  ->Fill( fabs( matchtrk_phi->at(it) - tp_phi->at(it) ) );
+            h_absResVsPt_eta_L[im-6]  ->Fill( fabs( matchtrk_eta->at(it) - tp_eta->at(it) ) );
+    }
+  }
       
       // ----------------------------------------------------------------------------------------------------------------
       // fill resolution vs. eta histograms
@@ -1026,6 +1054,26 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   TH1F* h2_resVsPt_eta_99   = new TH1F("resVsPt2_eta_99",  ";Tracking particle p_{T} [GeV]; #eta resolution [rad]",    20,0,100);
   TH1F* h2_resVsPt_d0_99    = new TH1F("resVsPt2_d0_99",   ";Tracking particle p_{T} [GeV]; d_{0} resolution [rad]",   20,0,100);
 
+  TH1F* h2_resVsPt_pt_L_68    = new TH1F("resVsPt2_pt_L_68",   ";Tracking particle p_{T} [GeV]; p_{T} resolution",         10,3,8);
+  TH1F* h2_resVsPt_ptRel_L_68 = new TH1F("resVsPt2_ptRel_L_68",";Tracking particle p_{T} [GeV]; p_{T} resolution / p_{T}", 10,3,8);
+  TH1F* h2_resVsPt_z0_L_68    = new TH1F("resVsPt2_z0_L_68",   ";Tracking particle p_{T} [GeV]; z_{0} resolution [cm]",    10,3,8);
+  TH1F* h2_resVsPt_phi_L_68   = new TH1F("resVsPt2_phi_L_68",  ";Tracking particle p_{T} [GeV]; #phi resolution [rad]",    10,3,8);
+  TH1F* h2_resVsPt_eta_L_68   = new TH1F("resVsPt2_eta_L_68",  ";Tracking particle p_{T} [GeV]; #eta resolution [rad]",    10,3,8);
+  TH1F* h2_resVsPt_d0_L_68    = new TH1F("resVsPt2_d0_L_68",   ";Tracking particle p_{T} [GeV]; d_{0} resolution [rad]",   10,3,8);
+
+  TH1F* h2_resVsPt_pt_L_90    = new TH1F("resVsPt2_pt_L_90",   ";Tracking particle p_{T} [GeV]; p_{T} resolution",         10,3,8);
+  TH1F* h2_resVsPt_ptRel_L_90 = new TH1F("resVsPt2_ptRel_L_90",";Tracking particle p_{T} [GeV]; p_{T} resolution / p_{T}", 10,3,8);
+  TH1F* h2_resVsPt_z0_L_90    = new TH1F("resVsPt2_z0_L_90",   ";Tracking particle p_{T} [GeV]; z_{0} resolution [cm]",    10,3,8);
+  TH1F* h2_resVsPt_phi_L_90   = new TH1F("resVsPt2_phi_L_90",  ";Tracking particle p_{T} [GeV]; #phi resolution [rad]",    10,3,8);
+  TH1F* h2_resVsPt_eta_L_90   = new TH1F("resVsPt2_eta_L_90",  ";Tracking particle p_{T} [GeV]; #eta resolution [rad]",    10,3,8);
+  TH1F* h2_resVsPt_d0_L_90    = new TH1F("resVsPt2_d0_L_90",   ";Tracking particle p_{T} [GeV]; d_{0} resolution [rad]",   10,3,8);
+
+  TH1F* h2_resVsPt_pt_L_99    = new TH1F("resVsPt2_pt_L_99",   ";Tracking particle p_{T} [GeV]; p_{T} resolution",         10,3,8);
+  TH1F* h2_resVsPt_ptRel_L_99 = new TH1F("resVsPt2_ptRel_L_99",";Tracking particle p_{T} [GeV]; p_{T} resolution / p_{T}", 10,3,8);
+  TH1F* h2_resVsPt_z0_L_99    = new TH1F("resVsPt2_z0_L_99",   ";Tracking particle p_{T} [GeV]; z_{0} resolution [cm]",    10,3,8);
+  TH1F* h2_resVsPt_phi_L_99   = new TH1F("resVsPt2_phi_L_99",  ";Tracking particle p_{T} [GeV]; #phi resolution [rad]",    10,3,8);
+  TH1F* h2_resVsPt_eta_L_99   = new TH1F("resVsPt2_eta_L_99",  ";Tracking particle p_{T} [GeV]; #eta resolution [rad]",    10,3,8);
+  TH1F* h2_resVsPt_d0_L_99    = new TH1F("resVsPt2_d0_L_99",   ";Tracking particle p_{T} [GeV]; d_{0} resolution [rad]",   10,3,8);
 
   for (int i=0; i<nRANGE; i++) {
     // set bin content and error
@@ -1105,7 +1153,32 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
     h2_resVsPt_d0_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_d0[i], 0.99 ));
   }
   
-  
+  for (int i=0; i<nRANGE_L; i++) {
+    h2_resVsPt_pt_L_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_pt_L[i], 0.68 ));
+    h2_resVsPt_pt_L_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_pt_L[i], 0.90 ));
+    h2_resVsPt_pt_L_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_pt_L[i], 0.99 ));
+
+    h2_resVsPt_ptRel_L_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_ptRel_L[i], 0.68 ));
+    h2_resVsPt_ptRel_L_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_ptRel_L[i], 0.90 ));
+    h2_resVsPt_ptRel_L_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_ptRel_L[i], 0.99 ));
+
+    h2_resVsPt_eta_L_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_eta_L[i], 0.68 ));
+    h2_resVsPt_eta_L_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_eta_L[i], 0.90 ));
+    h2_resVsPt_eta_L_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_eta_L[i], 0.99 ));
+
+    h2_resVsPt_z0_L_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_z0_L[i], 0.68 ));
+    h2_resVsPt_z0_L_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_z0_L[i], 0.90 ));
+    h2_resVsPt_z0_L_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_z0_L[i], 0.99 ));
+
+    h2_resVsPt_phi_L_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_phi_L[i], 0.68 ));
+    h2_resVsPt_phi_L_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_phi_L[i], 0.90 ));
+    h2_resVsPt_phi_L_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_phi_L[i], 0.99 ));
+
+    h2_resVsPt_d0_L_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_d0_L[i], 0.68 ));
+    h2_resVsPt_d0_L_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_d0_L[i], 0.90 ));
+    h2_resVsPt_d0_L_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsPt_d0_L[i], 0.99 ));
+  }
+
   // resolution vs. eta histograms
   TH1F* h2_resVsEta_eta   = new TH1F("resVsEta2_eta",   ";Tracking particle |#eta|; #eta resolution", 24,0,2.4);
   TH1F* h2_resVsEta_eta_L = new TH1F("resVsEta2_eta_L", ";Tracking particle |#eta|; #eta resolution", 24,0,2.4);
@@ -1152,17 +1225,41 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   TH1F* h2_resVsEta_d0_90   = new TH1F("resVsEta_d0_90",   ";Tracking particle |#eta|; d_{0} resolution [cm]", 24,0,2.4);
   TH1F* h2_resVsEta_d0_99   = new TH1F("resVsEta_d0_99",   ";Tracking particle |#eta|; d_{0} resolution [cm]", 24,0,2.4);
 
+  TH1F* h2_resVsEta_eta_L_68   = new TH1F("resVsEta_eta_L_68",  ";Tracking particle |#eta|; #eta resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_z0_L_68    = new TH1F("resVsEta_z0_L_68",   ";Tracking particle |#eta|; z_{0} resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_phi_L_68   = new TH1F("resVsEta_phi_L_68",  ";Tracking particle |#eta|; #phi resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_ptRel_L_68 = new TH1F("resVsEta_ptRel_L_68",";Tracking particle |#eta|; p_{T} resolution / p_{T} resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_d0_L_68    = new TH1F("resVsEta_d0_L_68",   ";Tracking particle |#eta|; d_{0} resolution [cm]", 24,0,2.4);
+
   TH1F* h2_resVsEta_eta_L_90   = new TH1F("resVsEta_eta_L_90",  ";Tracking particle |#eta|; #eta resolution [cm]", 24,0,2.4);
   TH1F* h2_resVsEta_z0_L_90    = new TH1F("resVsEta_z0_L_90",   ";Tracking particle |#eta|; z_{0} resolution [cm]", 24,0,2.4);
   TH1F* h2_resVsEta_phi_L_90   = new TH1F("resVsEta_phi_L_90",  ";Tracking particle |#eta|; #phi resolution [cm]", 24,0,2.4);
   TH1F* h2_resVsEta_ptRel_L_90 = new TH1F("resVsEta_ptRel_L_90",";Tracking particle |#eta|; p_{T} resolution / p_{T} resolution [cm]", 24,0,2.4);
   TH1F* h2_resVsEta_d0_L_90    = new TH1F("resVsEta_d0_L_90",   ";Tracking particle |#eta|; d_{0} resolution [cm]", 24,0,2.4);
 
+  TH1F* h2_resVsEta_eta_L_99   = new TH1F("resVsEta_eta_L_99",  ";Tracking particle |#eta|; #eta resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_z0_L_99    = new TH1F("resVsEta_z0_L_99",   ";Tracking particle |#eta|; z_{0} resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_phi_L_99   = new TH1F("resVsEta_phi_L_99",  ";Tracking particle |#eta|; #phi resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_ptRel_L_99 = new TH1F("resVsEta_ptRel_L_99",";Tracking particle |#eta|; p_{T} resolution / p_{T} resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_d0_L_99    = new TH1F("resVsEta_d0_L_99",   ";Tracking particle |#eta|; d_{0} resolution [cm]", 24,0,2.4);
+
+  TH1F* h2_resVsEta_eta_H_68   = new TH1F("resVsEta_eta_H_68",  ";Tracking particle |#eta|; #eta resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_z0_H_68    = new TH1F("resVsEta_z0_H_68",   ";Tracking particle |#eta|; z_{0} resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_phi_H_68   = new TH1F("resVsEta_phi_H_68",  ";Tracking particle |#eta|; #phi resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_ptRel_H_68 = new TH1F("resVsEta_ptRel_H_68",";Tracking particle |#eta|; p_{T} resolution / p_{T} resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_d0_H_68    = new TH1F("resVsEta_d0_H_68",   ";Tracking particle |#eta|; d_{0} resolution [cm]", 24,0,2.4);
+
   TH1F* h2_resVsEta_eta_H_90   = new TH1F("resVsEta_eta_H_90",  ";Tracking particle |#eta|; #eta resolution [cm]", 24,0,2.4);
   TH1F* h2_resVsEta_z0_H_90    = new TH1F("resVsEta_z0_H_90",   ";Tracking particle |#eta|; z_{0} resolution [cm]", 24,0,2.4);
   TH1F* h2_resVsEta_phi_H_90   = new TH1F("resVsEta_phi_H_90",  ";Tracking particle |#eta|; #phi resolution [cm]", 24,0,2.4);
   TH1F* h2_resVsEta_ptRel_H_90 = new TH1F("resVsEta_ptRel_H_90",";Tracking particle |#eta|; p_{T} resolution / p_{T} resolution [cm]", 24,0,2.4);
   TH1F* h2_resVsEta_d0_H_90    = new TH1F("resVsEta_d0_H_90",   ";Tracking particle |#eta|; d_{0} resolution [cm]", 24,0,2.4);
+
+  TH1F* h2_resVsEta_eta_H_99   = new TH1F("resVsEta_eta_H_99",  ";Tracking particle |#eta|; #eta resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_z0_H_99    = new TH1F("resVsEta_z0_H_99",   ";Tracking particle |#eta|; z_{0} resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_phi_H_99   = new TH1F("resVsEta_phi_H_99",  ";Tracking particle |#eta|; #phi resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_ptRel_H_99 = new TH1F("resVsEta_ptRel_H_99",";Tracking particle |#eta|; p_{T} resolution / p_{T} resolution [cm]", 24,0,2.4);
+  TH1F* h2_resVsEta_d0_H_99    = new TH1F("resVsEta_d0_H_99",   ";Tracking particle |#eta|; d_{0} resolution [cm]", 24,0,2.4);
 
 
 
@@ -1247,17 +1344,41 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
     h2_resVsEta_d0_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_d0[i], 0.99 ));
 
 
+    h2_resVsEta_eta_L_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_eta_L[i], 0.68 ));
+    h2_resVsEta_z0_L_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_z0_L[i], 0.68 ));
+    h2_resVsEta_phi_L_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_phi_L[i], 0.68 ));
+    h2_resVsEta_ptRel_L_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_ptRel_L[i], 0.68 ));
+    h2_resVsEta_d0_L_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_d0_L[i], 0.68 ));
+
     h2_resVsEta_eta_L_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_eta_L[i], 0.90 ));
     h2_resVsEta_z0_L_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_z0_L[i], 0.90 ));
     h2_resVsEta_phi_L_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_phi_L[i], 0.90 ));
     h2_resVsEta_ptRel_L_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_ptRel_L[i], 0.90 ));
     h2_resVsEta_d0_L_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_d0_L[i], 0.90 ));
 
+    h2_resVsEta_eta_L_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_eta_L[i], 0.99 ));
+    h2_resVsEta_z0_L_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_z0_L[i], 0.99 ));
+    h2_resVsEta_phi_L_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_phi_L[i], 0.99 ));
+    h2_resVsEta_ptRel_L_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_ptRel_L[i], 0.99 ));
+    h2_resVsEta_d0_L_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_d0_L[i], 0.99 ));
+
+    h2_resVsEta_eta_H_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_eta_H[i], 0.68 ));
+    h2_resVsEta_z0_H_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_z0_H[i], 0.68 ));
+    h2_resVsEta_phi_H_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_phi_H[i], 0.68 ));
+    h2_resVsEta_ptRel_H_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_ptRel_H[i], 0.68 ));
+    h2_resVsEta_d0_H_68->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_d0_H[i], 0.68 ));
+
     h2_resVsEta_eta_H_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_eta_H[i], 0.90 ));
     h2_resVsEta_z0_H_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_z0_H[i], 0.90 ));
     h2_resVsEta_phi_H_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_phi_H[i], 0.90 ));
     h2_resVsEta_ptRel_H_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_ptRel_H[i], 0.90 ));
     h2_resVsEta_d0_H_90->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_d0_H[i], 0.90 ));
+
+    h2_resVsEta_eta_H_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_eta_H[i], 0.99 ));
+    h2_resVsEta_z0_H_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_z0_H[i], 0.99 ));
+    h2_resVsEta_phi_H_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_phi_H[i], 0.99 ));
+    h2_resVsEta_ptRel_H_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_ptRel_H[i], 0.99 ));
+    h2_resVsEta_d0_H_99->SetBinContent(i+1, getIntervalContainingFractionOfEntries( h_absResVsEta_d0_H[i], 0.99 ));
 
 
 
@@ -1498,7 +1619,8 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   TString DIR = "TrkPlots/";
 
   // plots overlaying 68, 90, 99% confidence levels]
-  if (doDetailedPlots) {
+  // if (doDetailedPlots) {
+    // makeResidualIntervalPlot will save the individual plots to the root file
     makeResidualIntervalPlot( type, DIR, "resVsPt_ptRel", h2_resVsPt_ptRel_68, h2_resVsPt_ptRel_90, h2_resVsPt_ptRel_99, 0, 0.5 );
     makeResidualIntervalPlot( type, DIR, "resVsPt_pt", h2_resVsPt_pt_68, h2_resVsPt_pt_90, h2_resVsPt_pt_99, 0, 20 );
     makeResidualIntervalPlot( type, DIR, "resVsPt_z0", h2_resVsPt_z0_68, h2_resVsPt_z0_90, h2_resVsPt_z0_99, 0, 1.0 );
@@ -1506,60 +1628,36 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
     makeResidualIntervalPlot( type, DIR, "resVsPt_eta", h2_resVsPt_eta_68, h2_resVsPt_eta_90, h2_resVsPt_eta_99, 0, 0.03 );
     makeResidualIntervalPlot( type, DIR, "resVsPt_d0", h2_resVsPt_d0_68, h2_resVsPt_d0_90, h2_resVsPt_d0_99, 0, 0.02 );
 
+    makeResidualIntervalPlot( type, DIR, "resVsPt_L_ptRel", h2_resVsPt_ptRel_L_68, h2_resVsPt_ptRel_L_90, h2_resVsPt_ptRel_L_99, 0, 0.5 );
+    makeResidualIntervalPlot( type, DIR, "resVsPt_L_pt", h2_resVsPt_pt_L_68, h2_resVsPt_pt_L_90, h2_resVsPt_pt_L_99, 0, 20 );
+    makeResidualIntervalPlot( type, DIR, "resVsPt_L_z0", h2_resVsPt_z0_L_68, h2_resVsPt_z0_L_90, h2_resVsPt_z0_L_99, 0, 1.0 );
+    makeResidualIntervalPlot( type, DIR, "resVsPt_L_phi", h2_resVsPt_phi_L_68, h2_resVsPt_phi_L_90, h2_resVsPt_phi_L_99, 0, 0.1 );
+    makeResidualIntervalPlot( type, DIR, "resVsPt_L_eta", h2_resVsPt_eta_L_68, h2_resVsPt_eta_L_90, h2_resVsPt_eta_L_99, 0, 0.03 );
+    makeResidualIntervalPlot( type, DIR, "resVsPt_L_d0", h2_resVsPt_d0_L_68, h2_resVsPt_d0_L_90, h2_resVsPt_d0_L_99, 0, 0.02 );
+
     makeResidualIntervalPlot( type, DIR, "resVsEta_eta", h2_resVsEta_eta_68, h2_resVsEta_eta_90, h2_resVsEta_eta_99, 0, 0.03 );
     makeResidualIntervalPlot( type, DIR, "resVsEta_z0", h2_resVsEta_z0_68, h2_resVsEta_z0_90, h2_resVsEta_z0_99, 0, 1.0 );
     makeResidualIntervalPlot( type, DIR, "resVsEta_phi", h2_resVsEta_phi_68, h2_resVsEta_phi_90, h2_resVsEta_phi_99, 0, 0.05 );
     makeResidualIntervalPlot( type, DIR, "resVsEta_ptRel", h2_resVsEta_ptRel_68, h2_resVsEta_ptRel_90, h2_resVsEta_ptRel_99, 0, 0.4 );
     makeResidualIntervalPlot( type, DIR, "resVsEta_d0", h2_resVsEta_d0_68, h2_resVsEta_d0_90, h2_resVsEta_d0_99, 0, 0.02 );
-  }
+
+    makeResidualIntervalPlot( type, DIR, "resVsEta_L_eta", h2_resVsEta_eta_L_68, h2_resVsEta_eta_L_90, h2_resVsEta_eta_L_99, 0, 0.03 );
+    makeResidualIntervalPlot( type, DIR, "resVsEta_L_z0", h2_resVsEta_z0_L_68, h2_resVsEta_z0_L_90, h2_resVsEta_z0_L_99, 0, 1.0 );
+    makeResidualIntervalPlot( type, DIR, "resVsEta_L_phi", h2_resVsEta_phi_L_68, h2_resVsEta_phi_L_90, h2_resVsEta_phi_L_99, 0, 0.05 );
+    makeResidualIntervalPlot( type, DIR, "resVsEta_L_ptRel", h2_resVsEta_ptRel_L_68, h2_resVsEta_ptRel_L_90, h2_resVsEta_ptRel_L_99, 0, 0.4 );
+    makeResidualIntervalPlot( type, DIR, "resVsEta_L_d0", h2_resVsEta_d0_L_68, h2_resVsEta_d0_L_90, h2_resVsEta_d0_L_99, 0, 0.02 );
+
+    makeResidualIntervalPlot( type, DIR, "resVsEta_H_eta", h2_resVsEta_eta_H_68, h2_resVsEta_eta_H_90, h2_resVsEta_eta_H_99, 0, 0.03 );
+    makeResidualIntervalPlot( type, DIR, "resVsEta_H_z0", h2_resVsEta_z0_H_68, h2_resVsEta_z0_H_90, h2_resVsEta_z0_H_99, 0, 1.0 );
+    makeResidualIntervalPlot( type, DIR, "resVsEta_H_phi", h2_resVsEta_phi_H_68, h2_resVsEta_phi_H_90, h2_resVsEta_phi_H_99, 0, 0.05 );
+    makeResidualIntervalPlot( type, DIR, "resVsEta_H_ptRel", h2_resVsEta_ptRel_H_68, h2_resVsEta_ptRel_H_90, h2_resVsEta_ptRel_H_99, 0, 0.4 );
+    makeResidualIntervalPlot( type, DIR, "resVsEta_H_d0", h2_resVsEta_d0_H_68, h2_resVsEta_d0_H_90, h2_resVsEta_d0_H_99, 0, 0.02 );
+  // }
 
 
   // ----------------------------------------------------------------------------------------------------------
   // resoultion vs pt
   // ----------------------------------------------------------------------------------------------------------
-
-  h2_resVsPt_pt_90->SetMinimum(0);
-  h2_resVsPt_pt_90->SetMarkerStyle(20);
-  h2_resVsPt_pt_90->Draw("p");
-  h2_resVsPt_pt_90->Write();
-  c.SaveAs(DIR+type+"_resVsPt_pt_90.eps");
-  c.SaveAs(DIR+type+"_resVsPt_pt_90.png");
-
-  h2_resVsPt_ptRel_90->SetMinimum(0);
-  h2_resVsPt_ptRel_90->SetMarkerStyle(20);
-  h2_resVsPt_ptRel_90->Draw("p");
-  h2_resVsPt_ptRel_90->Write();
-  c.SaveAs(DIR+type+"_resVsPt_ptRel_90.eps");
-  c.SaveAs(DIR+type+"_resVsPt_ptRel_90.png");
-
-  h2_resVsPt_z0_90->SetMinimum(0);
-  h2_resVsPt_z0_90->SetMarkerStyle(20);
-  h2_resVsPt_z0_90->Draw("p");
-  h2_resVsPt_z0_90->Write();
-  c.SaveAs(DIR+type+"_resVsPt_z0_90.eps");
-  c.SaveAs(DIR+type+"_resVsPt_z0_90.png");
-
-  h2_resVsPt_phi_90->SetMinimum(0);
-  h2_resVsPt_phi_90->SetMarkerStyle(20);
-  h2_resVsPt_phi_90->Draw("p");
-  h2_resVsPt_phi_90->Write();
-  c.SaveAs(DIR+type+"_resVsPt_phi_90.eps");
-  c.SaveAs(DIR+type+"_resVsPt_phi_90.png");
-
-  h2_resVsPt_eta_90->SetMinimum(0);
-  h2_resVsPt_eta_90->SetMarkerStyle(20);
-  h2_resVsPt_eta_90->Draw("p");
-  h2_resVsPt_eta_90->Write();
-  c.SaveAs(DIR+type+"_resVsPt_eta_90.eps");
-  c.SaveAs(DIR+type+"_resVsPt_eta_90.png");
-
-  h2_resVsPt_phi_90->SetMinimum(0);
-  h2_resVsPt_d0_90->SetMarkerStyle(20);
-  h2_resVsPt_d0_90->Draw("p");
-  h2_resVsPt_d0_90->Write();
-  c.SaveAs(DIR+type+"_resVsPt_d0_90.eps");
-  c.SaveAs(DIR+type+"_resVsPt_d0_90.png");
-
 
   if (doDetailedPlots) {
     h2_resVsPt_eta->Write();
@@ -1595,111 +1693,6 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   // ----------------------------------------------------------------------------------------------------------
   // resolution vs eta
   // ----------------------------------------------------------------------------------------------------------
-
-  h2_resVsEta_eta_90->SetMinimum(0);
-  h2_resVsEta_eta_90->SetMarkerStyle(20);
-  h2_resVsEta_eta_90->Draw("p");
-  h2_resVsEta_eta_90->Write();
-  c.SaveAs(DIR+type+"_resVsEta_eta_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_eta_90.png");
-
-  h2_resVsEta_eta_L_90->Draw();
-  h2_resVsEta_eta_L_90->Write();
-  sprintf(ctxt,"p_{T} < 8 GeV");
-  mySmallText(0.22,0.82,1,ctxt);
-  c.SaveAs(DIR+type+"_resVsEta_eta_L_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_eta_L_90.png");
-  
-  h2_resVsEta_eta_H_90->Draw();
-  h2_resVsEta_eta_H_90->Write();
-  sprintf(ctxt,"p_{T} > 8 GeV");
-  mySmallText(0.22,0.82,1,ctxt);
-  c.SaveAs(DIR+type+"_resVsEta_eta_H_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_eta_H_90.png");
-
-  h2_resVsEta_z0_90->SetMinimum(0);
-  h2_resVsEta_z0_90->SetMarkerStyle(20);
-  h2_resVsEta_z0_90->Draw("p");
-  h2_resVsEta_z0_90->Write();
-  c.SaveAs(DIR+type+"_resVsEta_z0_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_z0_90.png");
-
-  h2_resVsEta_z0_L_90->Draw();
-  h2_resVsEta_z0_L_90->Write();
-  sprintf(ctxt,"p_{T} < 8 GeV");
-  mySmallText(0.22,0.82,1,ctxt);
-  c.SaveAs(DIR+type+"_resVsEta_z0_L_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_z0_L_90.png");
-  
-  h2_resVsEta_z0_H_90->Draw();
-  h2_resVsEta_z0_H_90->Write();
-  sprintf(ctxt,"p_{T} > 8 GeV");
-  mySmallText(0.22,0.82,1,ctxt);
-  c.SaveAs(DIR+type+"_resVsEta_z0_H_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_z0_H_90.png");
-
-  h2_resVsEta_d0_90->Draw();
-  h2_resVsEta_d0_90->Write();
-  c.SaveAs(DIR+type+"_resVsEta_d0_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_d0_90.png");
-
-  h2_resVsEta_d0_L_90->Draw();
-  h2_resVsEta_d0_L_90->Write();
-  sprintf(ctxt,"p_{T} < 8 GeV");
-  mySmallText(0.22,0.82,1,ctxt);
-  c.SaveAs(DIR+type+"_resVsEta_d0_L_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_d0_L_90.png");
-
-  h2_resVsEta_d0_H_90->Draw();
-  h2_resVsEta_d0_H_90->Write();
-  sprintf(ctxt,"p_{T} > 8 GeV");
-  mySmallText(0.22,0.82,1,ctxt);
-  c.SaveAs(DIR+type+"_resVsEta_d0_H_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_d0_H_90.png");
-
-  h2_resVsEta_phi_90->SetMinimum(0);
-  h2_resVsEta_phi_90->SetMarkerStyle(20);
-  h2_resVsEta_phi_90->Draw("p");
-  h2_resVsEta_phi_90->Write();
-  c.SaveAs(DIR+type+"_resVsEta_phi_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_phi_90.png");
-
-  h2_resVsEta_phi_L_90->Draw();
-  h2_resVsEta_phi_L_90->Write();
-  sprintf(ctxt,"p_{T} < 8 GeV");
-  mySmallText(0.22,0.82,1,ctxt);
-  c.SaveAs(DIR+type+"_resVsEta_phi_L_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_phi_L_90.png");
-
-  h2_resVsEta_phi_H_90->Draw();
-  h2_resVsEta_phi_H_90->Write();
-  sprintf(ctxt,"p_{T} > 8 GeV");
-  mySmallText(0.22,0.82,1,ctxt);
-  c.SaveAs(DIR+type+"_resVsEta_phi_H_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_phi_H_90.png");
-
-
-  h2_resVsEta_ptRel_90->SetMinimum(0);
-  h2_resVsEta_ptRel_90->SetMarkerStyle(20);
-  h2_resVsEta_ptRel_90->Draw("p");
-  h2_resVsEta_ptRel_90->Write();
-  c.SaveAs(DIR+type+"_resVsEta_ptRel_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_ptRel_90.png");
-
-  h2_resVsEta_ptRel_L_90->Draw();
-  h2_resVsEta_ptRel_L_90->Write();
-  sprintf(ctxt,"p_{T} < 8 GeV");
-  mySmallText(0.22,0.82,1,ctxt);
-  c.SaveAs(DIR+type+"_resVsEta_ptRel_L_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_ptRel_L_90.png");
-
-  h2_resVsEta_ptRel_H_90->Draw();
-  h2_resVsEta_ptRel_H_90->Write();
-  sprintf(ctxt,"p_{T} > 8 GeV");
-  mySmallText(0.22,0.82,1,ctxt);
-  c.SaveAs(DIR+type+"_resVsEta_ptRel_H_90.eps");
-  c.SaveAs(DIR+type+"_resVsEta_ptRel_H_90.png");
-
 
   if (doDetailedPlots) {
     h2_resVsEta_eta->Write();

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/compareEfficiency.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/compareEfficiency.py
@@ -149,7 +149,7 @@ def setupLegend(sample, histograms, PULabels):
   l.SetLineColor(0)
   l.SetTextSize(0.04)
   l.AddEntry(histograms['PU0_wt'], "With truncation", "p")
-  l.AddEntry(histograms['PU0_wt'], "Without truncation", "l")
+  l.AddEntry(histograms['PU0_wot'], "Without truncation", "l")
   l.AddEntry(None,"","")
 
   if histograms['PU0_wt'] != None or histograms['PU0_wot'] != None :

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/compareResolution.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/compareResolution.py
@@ -158,7 +158,7 @@ def setupLegend(sample, histograms, PULabels):
   l.SetLineColor(0)
   l.SetTextSize(0.04)
   l.AddEntry(histograms['PU0_wt'], "With truncation", "p")
-  l.AddEntry(histograms['PU0_wt'], "Without truncation", "l")
+  l.AddEntry(histograms['PU0_wot'], "Without truncation", "l")
   l.AddEntry(None,"","")
 
   if histograms['PU0_wt'] != None or histograms['PU0_wot'] != None :
@@ -177,6 +177,11 @@ def setupLegend(sample, histograms, PULabels):
 
   return l
 
+def removeFirstBin( histograms ):
+  for name,h in histograms.iteritems():
+    if h != None:
+      h.GetXaxis().SetRangeUser(5,100)
+
 # ----------------------------------------------------------------------------------------------------------------
 # Main script
 def compareResolution(what, sample, ptRange=0, pdgid=0):
@@ -186,8 +191,15 @@ def compareResolution(what, sample, ptRange=0, pdgid=0):
   PULabels = ["<PU>=0", "<PU>=140", "<PU>=200"]
   ptRangeLabels = ["2 < P_{T} < 8 GeV","P_{T} > 8 GeV"]
 
+  if 'resVsPt2' in what and ptRange == 'L':
+    what += '_L'
+
   # Get histograms
   histograms68, histograms99 = getAllHistogramsFromFile( what, sample, ptRange, pdgid )
+
+  # Need to remove first (empty bin)
+  if 'resVsPt2' in what and ptRange == 'H':
+    removeFirstBin(histograms68)
 
   canvas = r.TCanvas()
 
@@ -240,7 +252,7 @@ def compareResolution(what, sample, ptRange=0, pdgid=0):
   # Save canvas
   if not os.path.isdir('OverlayPlots'):
     os.mkdir('OverlayPlots')
-  outputFileName = "OverlayPlots/{sample}_{what}_{ptRange}.pdf".format( sample = sample, what=what, ptRange=ptRange )
+  outputFileName = "OverlayPlots/{sample}_{what}.pdf".format( sample = sample, what=what )
   if sample == 'TTbar':
     if pdgid == 13:
       outputFileName = "OverlayPlots/{sample}_muons_{what}.pdf".format( sample = sample, what=what )
@@ -270,10 +282,10 @@ if __name__ == '__main__':
   }
   for sample, pdg in samplePdg.iteritems():
     for ptRange in ['L','H']:
-      compareResolution("resVsEta_phi",sample,ptRange,pdg)
-      compareResolution("resVsEta_z0",sample,ptRange,pdg)
-      compareResolution("resVsEta_ptRel",sample,ptRange,pdg)
-      compareResolution("resVsEta_eta",sample,ptRange,pdg)
+      compareResolution("resVsEta_phi_"+ptRange,sample,ptRange,pdg)
+      compareResolution("resVsEta_z0_"+ptRange,sample,ptRange,pdg)
+      compareResolution("resVsEta_ptRel_"+ptRange,sample,ptRange,pdg)
+      compareResolution("resVsEta_eta_"+ptRange,sample,ptRange,pdg)
 
       compareResolution("resVsPt2_phi",sample,ptRange,pdg)
       compareResolution("resVsPt2_z0",sample,ptRange,pdg)

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/templateSlidesConfig.json
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/templateSlidesConfig.json
@@ -35,10 +35,10 @@
             "title": "Baseline Metrics: single muon",
             "toptext": "Resolution vs pT 8-100 GeV",
             "plots": [
-                ["../OverlayPlots/Muon_resVsPt2_eta_H.pdf",     ""],
-                ["../OverlayPlots/Muon_resVsPt2_phi_H.pdf",     ""],
-                ["../OverlayPlots/Muon_resVsPt2_ptRel_H.pdf",   ""],
-                ["../OverlayPlots/Muon_resVsPt2_z0_H.pdf",      ""]
+                ["../OverlayPlots/Muon_resVsPt2_eta.pdf",     ""],
+                ["../OverlayPlots/Muon_resVsPt2_phi.pdf",     ""],
+                ["../OverlayPlots/Muon_resVsPt2_ptRel.pdf",   ""],
+                ["../OverlayPlots/Muon_resVsPt2_z0.pdf",      ""]
             ],
             "bottomtext": ""
         },
@@ -96,10 +96,10 @@
             "title": "Baseline Metrics: single pion",
             "toptext": "Resolution vs pT 8-100 GeV",
             "plots": [
-                ["../OverlayPlots/Pion_resVsPt2_eta_H.pdf",     ""],
-                ["../OverlayPlots/Pion_resVsPt2_phi_H.pdf",     ""],
-                ["../OverlayPlots/Pion_resVsPt2_ptRel_H.pdf",   ""],
-                ["../OverlayPlots/Pion_resVsPt2_z0_H.pdf",      ""]
+                ["../OverlayPlots/Pion_resVsPt2_eta.pdf",     ""],
+                ["../OverlayPlots/Pion_resVsPt2_phi.pdf",     ""],
+                ["../OverlayPlots/Pion_resVsPt2_ptRel.pdf",   ""],
+                ["../OverlayPlots/Pion_resVsPt2_z0.pdf",      ""]
             ],
             "bottomtext": ""
         },
@@ -157,10 +157,10 @@
             "title": "Baseline Metrics: single electron",
             "toptext": "Resolution vs pT 8-100 GeV",
             "plots": [
-                ["../OverlayPlots/Electron_resVsPt2_eta_H.pdf",     ""],
-                ["../OverlayPlots/Electron_resVsPt2_phi_H.pdf",     ""],
-                ["../OverlayPlots/Electron_resVsPt2_ptRel_H.pdf",   ""],
-                ["../OverlayPlots/Electron_resVsPt2_z0_H.pdf",      ""]
+                ["../OverlayPlots/Electron_resVsPt2_eta.pdf",     ""],
+                ["../OverlayPlots/Electron_resVsPt2_phi.pdf",     ""],
+                ["../OverlayPlots/Electron_resVsPt2_ptRel.pdf",   ""],
+                ["../OverlayPlots/Electron_resVsPt2_z0.pdf",      ""]
             ],
             "bottomtext": ""
         },

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/templateSlidesConfig.json
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/templateSlidesConfig.json
@@ -1,0 +1,298 @@
+{
+    "frontpage": {
+        "title": "Template Slides",
+        "subtitle": "TMT",
+        "author": "My collaboration"
+
+    },
+
+    "slides": [
+        {
+            "title": "Baseline Metrics: single muon",
+            "toptext": "Efficiency vs pT, eta : 2-8 GeV, 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/Muon_eff_pt_L.pdf",   "" ],
+                ["../OverlayPlots/Muon_eff_pt_H.pdf",   "" ],
+                ["../OverlayPlots/Muon_eff_eta_L.pdf",  "" ],
+                ["../OverlayPlots/Muon_eff_eta_H.pdf",  "" ]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: single muon",
+            "toptext": "Resolution vs pT 2-8 GeV",
+            "plots": [
+                ["../OverlayPlots/Muon_resVsPt2_eta_L.pdf",     ""],
+                ["../OverlayPlots/Muon_resVsPt2_phi_L.pdf",     ""],
+                ["../OverlayPlots/Muon_resVsPt2_ptRel_L.pdf",   ""],
+                ["../OverlayPlots/Muon_resVsPt2_z0_L.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: single muon",
+            "toptext": "Resolution vs pT 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/Muon_resVsPt2_eta_H.pdf",     ""],
+                ["../OverlayPlots/Muon_resVsPt2_phi_H.pdf",     ""],
+                ["../OverlayPlots/Muon_resVsPt2_ptRel_H.pdf",   ""],
+                ["../OverlayPlots/Muon_resVsPt2_z0_H.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+
+        {
+            "title": "Baseline Metrics: single muon",
+            "toptext": "Resolution vs eta, pT 2-8 GeV",
+            "plots": [
+                ["../OverlayPlots/Muon_resVsEta_eta_L.pdf",     ""],
+                ["../OverlayPlots/Muon_resVsEta_phi_L.pdf",     ""],
+                ["../OverlayPlots/Muon_resVsEta_ptRel_L.pdf",   ""],
+                ["../OverlayPlots/Muon_resVsEta_z0_L.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: single muon",
+            "toptext": "Resolution vs eta, pT 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/Muon_resVsEta_eta_H.pdf",     ""],
+                ["../OverlayPlots/Muon_resVsEta_phi_H.pdf",     ""],
+                ["../OverlayPlots/Muon_resVsEta_ptRel_H.pdf",   ""],
+                ["../OverlayPlots/Muon_resVsEta_z0_H.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: single pion",
+            "toptext": "Efficiency vs pT, eta : 2-8 GeV, 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/Pion_eff_pt_L.pdf",   "" ],
+                ["../OverlayPlots/Pion_eff_pt_H.pdf",   "" ],
+                ["../OverlayPlots/Pion_eff_eta_L.pdf",  "" ],
+                ["../OverlayPlots/Pion_eff_eta_H.pdf",  "" ]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: single pion",
+            "toptext": "Resolution vs pT 2-8 GeV",
+            "plots": [
+                ["../OverlayPlots/Pion_resVsPt2_eta_L.pdf",     ""],
+                ["../OverlayPlots/Pion_resVsPt2_phi_L.pdf",     ""],
+                ["../OverlayPlots/Pion_resVsPt2_ptRel_L.pdf",   ""],
+                ["../OverlayPlots/Pion_resVsPt2_z0_L.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: single pion",
+            "toptext": "Resolution vs pT 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/Pion_resVsPt2_eta_H.pdf",     ""],
+                ["../OverlayPlots/Pion_resVsPt2_phi_H.pdf",     ""],
+                ["../OverlayPlots/Pion_resVsPt2_ptRel_H.pdf",   ""],
+                ["../OverlayPlots/Pion_resVsPt2_z0_H.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+
+        {
+            "title": "Baseline Metrics: single pion",
+            "toptext": "Resolution vs eta, pT 2-8 GeV",
+            "plots": [
+                ["../OverlayPlots/Pion_resVsEta_eta_L.pdf",     ""],
+                ["../OverlayPlots/Pion_resVsEta_phi_L.pdf",     ""],
+                ["../OverlayPlots/Pion_resVsEta_ptRel_L.pdf",   ""],
+                ["../OverlayPlots/Pion_resVsEta_z0_L.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: single pion",
+            "toptext": "Resolution vs eta, pT 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/Pion_resVsEta_eta_H.pdf",     ""],
+                ["../OverlayPlots/Pion_resVsEta_phi_H.pdf",     ""],
+                ["../OverlayPlots/Pion_resVsEta_ptRel_H.pdf",   ""],
+                ["../OverlayPlots/Pion_resVsEta_z0_H.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: single electron",
+            "toptext": "Efficiency vs pT, eta : 2-8 GeV, 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/Electron_eff_pt_L.pdf",   "" ],
+                ["../OverlayPlots/Electron_eff_pt_H.pdf",   "" ],
+                ["../OverlayPlots/Electron_eff_eta_L.pdf",  "" ],
+                ["../OverlayPlots/Electron_eff_eta_H.pdf",  "" ]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: single electron",
+            "toptext": "Resolution vs pT 2-8 GeV",
+            "plots": [
+                ["../OverlayPlots/Electron_resVsPt2_eta_L.pdf",     ""],
+                ["../OverlayPlots/Electron_resVsPt2_phi_L.pdf",     ""],
+                ["../OverlayPlots/Electron_resVsPt2_ptRel_L.pdf",   ""],
+                ["../OverlayPlots/Electron_resVsPt2_z0_L.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: single electron",
+            "toptext": "Resolution vs pT 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/Electron_resVsPt2_eta_H.pdf",     ""],
+                ["../OverlayPlots/Electron_resVsPt2_phi_H.pdf",     ""],
+                ["../OverlayPlots/Electron_resVsPt2_ptRel_H.pdf",   ""],
+                ["../OverlayPlots/Electron_resVsPt2_z0_H.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+
+        {
+            "title": "Baseline Metrics: single electron",
+            "toptext": "Resolution vs eta, pT 2-8 GeV",
+            "plots": [
+                ["../OverlayPlots/Electron_resVsEta_eta_L.pdf",     ""],
+                ["../OverlayPlots/Electron_resVsEta_phi_L.pdf",     ""],
+                ["../OverlayPlots/Electron_resVsEta_ptRel_L.pdf",   ""],
+                ["../OverlayPlots/Electron_resVsEta_z0_L.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: single electron",
+            "toptext": "Resolution vs eta, pT 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/Electron_resVsEta_eta_H.pdf",     ""],
+                ["../OverlayPlots/Electron_resVsEta_phi_H.pdf",     ""],
+                ["../OverlayPlots/Electron_resVsEta_ptRel_H.pdf",   ""],
+                ["../OverlayPlots/Electron_resVsEta_z0_H.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+       {
+            "title": "Baseline Metrics: muon in ttbar",
+            "toptext": "Efficiency vs pT, eta : 2-8 GeV, 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/TTbar_muons_eff_pt_L.pdf",   "" ],
+                ["../OverlayPlots/TTbar_muons_eff_pt_H.pdf",   "" ],
+                ["../OverlayPlots/TTbar_muons_eff_eta_L.pdf",  "" ],
+                ["../OverlayPlots/TTbar_muons_eff_eta_H.pdf",  "" ]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: muon in ttbar",
+            "toptext": "Resolution vs pT 2-8 GeV",
+            "plots": [
+                ["../OverlayPlots/TTbar_muons_resVsPt2_eta.pdf",     ""],
+                ["../OverlayPlots/TTbar_muons_resVsPt2_phi.pdf",     ""],
+                ["../OverlayPlots/TTbar_muons_resVsPt2_ptRel.pdf",   ""],
+                ["../OverlayPlots/TTbar_muons_resVsPt2_z0.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: muon in ttbar",
+            "toptext": "Resolution vs eta, pT 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/TTbar_muons_resVsEta_eta.pdf",     ""],
+                ["../OverlayPlots/TTbar_muons_resVsEta_phi.pdf",     ""],
+                ["../OverlayPlots/TTbar_muons_resVsEta_ptRel.pdf",   ""],
+                ["../OverlayPlots/TTbar_muons_resVsEta_z0.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Track Isolation",
+            "toptext": "Prompt / non-prompt muons in ttbar + PU",
+            "plots": [
+                ["../OverlayPlots/Isolation.pdf",     ""]
+            ],
+            "bottomtext": ""
+        },
+
+       {
+            "title": "Tracking in Jets",
+            "toptext": "Efficiency for all tracks with pT > 3 GeV in ttbar jets",
+            "plots": [
+                ["../OverlayPlots/TTbar_injet_eff_pt.pdf",   "" ],
+                ["../OverlayPlots/TTbar_injet_highpt_eff_pt.pdf",   "" ],
+                ["../OverlayPlots/TTbar_injet_eff_eta.pdf",  "" ],
+                ["../OverlayPlots/TTbar_injet_highpt_eff_eta.pdf",  "" ]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Tracking in Jets",
+            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT less than 30 GeV",
+            "plots": [
+                ["../OverlayPlots/TTbar_injet_resVsPt2_eta.pdf",     ""],
+                ["../OverlayPlots/TTbar_injet_resVsPt2_phi.pdf",     ""],
+                ["../OverlayPlots/TTbar_injet_resVsPt2_ptRel.pdf",   ""],
+                ["../OverlayPlots/TTbar_injet_resVsPt2_z0.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Tracking in Jets",
+            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT less than 30 GeV",
+            "plots": [
+                ["../OverlayPlots/TTbar_injet_resVsEta_eta.pdf",     ""],
+                ["../OverlayPlots/TTbar_injet_resVsEta_phi.pdf",     ""],
+                ["../OverlayPlots/TTbar_injet_resVsEta_ptRel.pdf",   ""],
+                ["../OverlayPlots/TTbar_injet_resVsEta_z0.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Tracking in Jets",
+            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT above 30 GeV",
+            "plots": [
+                ["../OverlayPlots/TTbar_injet_highpt_resVsPt2_eta.pdf",     ""],
+                ["../OverlayPlots/TTbar_injet_highpt_resVsPt2_phi.pdf",     ""],
+                ["../OverlayPlots/TTbar_injet_highpt_resVsPt2_ptRel.pdf",   ""],
+                ["../OverlayPlots/TTbar_injet_highpt_resVsPt2_z0.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Tracking in Jets",
+            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT above 30 GeV",
+            "plots": [
+                ["../OverlayPlots/TTbar_injet_highpt_resVsEta_eta.pdf",     ""],
+                ["../OverlayPlots/TTbar_injet_highpt_resVsEta_phi.pdf",     ""],
+                ["../OverlayPlots/TTbar_injet_highpt_resVsEta_ptRel.pdf",   ""],
+                ["../OverlayPlots/TTbar_injet_highpt_resVsEta_z0.pdf",      ""]
+            ],
+            "bottomtext": ""
+        }
+    ]
+}


### PR DESCRIPTION
- Include resolution plots vs pt for the low pt range (2-8GeV)
I noticed that makeResidualIntervalPlot saves the individual interval plots to the output root file, which is why I've removed lines that repeat this.

-Include a json config file for the template slides.  I will send round further instructions by email.

-I've also made a few minor changes to comapreResolution.py and compareEfficiency.py