### PR TITLE
Overlay plots

### DIFF
--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/L1TrackNtuplePlot.C
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/L1TrackNtuplePlot.C
@@ -420,6 +420,14 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   TH1F* h_tp_vspt  = new TH1F("tp_vspt", ";TP p_{T} [GeV]; ",40,0,20);
 
 
+  TH1F* h_tp_z0    = new TH1F("tp_z0",   ";Tracking particle z_{0} [cm]; Tracking particles / 1.0 cm",    50, -25.0, 25.0);
+  TH1F* h_tp_z0_L    = new TH1F("tp_z0_L",   ";Tracking particle z_{0} [cm]; Tracking particles / 1.0 cm",    50, -25.0, 25.0);
+  TH1F* h_tp_z0_H    = new TH1F("tp_z0_H",   ";Tracking particle z_{0} [cm]; Tracking particles / 1.0 cm",    50, -25.0, 25.0);
+
+  TH1F* h_match_tp_z0    = new TH1F("match_tp_z0",   ";Tracking particle z_{0} [cm]; Tracking particles / 1.0 cm",    50, -25.0, 25.0);
+  TH1F* h_match_tp_z0_L    = new TH1F("match_tp_z0_L",   ";Tracking particle z_{0} [cm]; Tracking particles / 1.0 cm",    50, -25.0, 25.0);
+  TH1F* h_match_tp_z0_H    = new TH1F("match_tp_z0_H",   ";Tracking particle z_{0} [cm]; Tracking particles / 1.0 cm",    50, -25.0, 25.0);
+
 
   // ----------------------------------------------------------------------------------------------------------------
   //
@@ -428,11 +436,9 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   // ----------------------------------------------------------------------------------------------------------------
 
   TH1F* h_tp_phi   = new TH1F("tp_phi",  ";Tracking particle #phi [rad]; Tracking particles / 0.1",       64, -3.2,   3.2);
-  TH1F* h_tp_z0    = new TH1F("tp_z0",   ";Tracking particle z_{0} [cm]; Tracking particles / 1.0 cm",    50, -25.0, 25.0);
   TH1F* h_tp_d0    = new TH1F("tp_d0",   ";Tracking particle d_{0} [cm]; Tracking particles / 0.0004 cm",100, -0.02, 0.02);
 
   TH1F* h_match_tp_phi   = new TH1F("match_tp_phi",  ";Tracking particle #phi [rad]; Tracking particles / 0.1",       64, -3.2,   3.2);
-  TH1F* h_match_tp_z0    = new TH1F("match_tp_z0",   ";Tracking particle z_{0} [cm]; Tracking particles / 1.0 cm",    50, -25.0, 25.0);
   TH1F* h_match_tp_d0    = new TH1F("match_tp_d0",   ";Tracking particle d_{0} [cm]; Tracking particles / 0.0004 cm",100, -0.02,   0.02);
 
   TH1F* h_match_trk_nstub   = new TH1F("match_trk_nstub",   ";Number of stubs; L1 tracks / 1.0", 15, 0, 15);
@@ -724,8 +730,14 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
 	h_tp_z0->Fill(tp_z0->at(it));
 	h_tp_d0->Fill(tp_d0->at(it));
 	
-	if (tp_pt->at(it) < 8.0) h_tp_eta_L->Fill(tp_eta->at(it));
-	else h_tp_eta_H->Fill(tp_eta->at(it));
+	if (tp_pt->at(it) < 8.0) {
+    h_tp_eta_L->Fill(tp_eta->at(it));
+    h_tp_z0_L->Fill(tp_z0->at(it));
+  }
+	else {
+    h_tp_eta_H->Fill(tp_eta->at(it));
+    h_tp_z0_H->Fill(tp_z0->at(it));
+  }
 	
       }
       
@@ -824,8 +836,14 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
 	else if (fabs(tp_eta->at(it)) < 1.75) n_match_eta1p75++;
 	else n_match_eta2p5++;
 	
-	if (tp_pt->at(it) < 8.0) h_match_tp_eta_L->Fill(tp_eta->at(it));
-	else h_match_tp_eta_H->Fill(tp_eta->at(it));
+	if (tp_pt->at(it) < 8.0) {
+    h_match_tp_eta_L->Fill(tp_eta->at(it));
+    h_match_tp_z0_L->Fill(tp_z0->at(it));
+  }
+	else {
+    h_match_tp_z0_H->Fill(tp_z0->at(it));
+    h_match_tp_eta_H->Fill(tp_eta->at(it));
+  }
       }
       
       
@@ -1965,6 +1983,20 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   h_eff_z0->GetYaxis()->SetTitle("Efficiency");
   h_eff_z0->Divide(h_match_tp_z0, h_tp_z0, 1.0, 1.0, "B");
 
+  h_match_tp_z0_L->Sumw2();
+  h_tp_z0_L->Sumw2();
+  TH1F* h_eff_z0_L = (TH1F*) h_match_tp_z0_L->Clone();
+  h_eff_z0_L->SetName("eff_z0_L");
+  h_eff_z0_L->GetYaxis()->SetTitle("Efficiency");
+  h_eff_z0_L->Divide(h_match_tp_z0_L, h_tp_z0_L, 1.0, 1.0, "B");
+
+  h_match_tp_z0_H->Sumw2();
+  h_tp_z0_H->Sumw2();
+  TH1F* h_eff_z0_H = (TH1F*) h_match_tp_z0_H->Clone();
+  h_eff_z0_H->SetName("eff_z0_H");
+  h_eff_z0_H->GetYaxis()->SetTitle("Efficiency");
+  h_eff_z0_H->Divide(h_match_tp_z0_H, h_tp_z0_H, 1.0, 1.0, "B");
+
   h_match_tp_d0->Sumw2();
   h_tp_d0->Sumw2();
   TH1F* h_eff_d0 = (TH1F*) h_match_tp_d0->Clone();
@@ -1982,6 +2014,8 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   h_eff_eta_H ->SetAxisRange(0,1.1,"Y");
   h_eff_phi ->SetAxisRange(0,1.1,"Y");
   h_eff_z0  ->SetAxisRange(0,1.1,"Y");
+  h_eff_z0_L  ->SetAxisRange(0,1.1,"Y");
+  h_eff_z0_H  ->SetAxisRange(0,1.1,"Y");
   h_eff_d0  ->SetAxisRange(0,1.1,"Y");
 
   if (type.Contains("Electron") || type.Contains("Pion")) h_eff_pt->SetAxisRange(0,49,"X");
@@ -2040,6 +2074,13 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
   c.SaveAs(DIR+type+"_eff_eta_H.eps");
   c.SaveAs(DIR+type+"_eff_eta_H.png");
 
+  h_eff_z0->Draw();
+  h_eff_z0->Write();
+  c.SaveAs(DIR+type+"_eff_z0.eps");
+  c.SaveAs(DIR+type+"_eff_z0.png");
+
+  h_eff_z0_L->Write();
+  h_eff_z0_H->Write();
 
   if (doDetailedPlots) {
     h_eff_phi->Draw();
@@ -2052,11 +2093,6 @@ void L1TrackNtuplePlot(TString type, int TP_select_injet=0, int TP_select_pdgid=
       c.SaveAs(DIR+type+"_eff_phi_zoom.eps");
       c.SaveAs(DIR+type+"_eff_phi_zoom.png");
     }
-    
-    h_eff_z0->Draw();
-    h_eff_z0->Write();
-    c.SaveAs(DIR+type+"_eff_z0.eps");
-    c.SaveAs(DIR+type+"_eff_z0.png");
     
     h_eff_d0->Draw();
     h_eff_d0->Write();

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/PlotL1PV.C
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/PlotL1PV.C
@@ -120,6 +120,10 @@ void PlotL1PV(TString name) {
   // ----------------------------------------------------------------------------------------------------------------
 
 
+  //
+  // Output file
+  // 
+  TFile* fout = new TFile("output_L1PV_"+inputFile+"_"+fitter+".root","recreate");
 
   // ----------------------------------------------------------------------------------------------------------------
   // write/plot histograms
@@ -166,7 +170,8 @@ void PlotL1PV(TString name) {
   }
   h_zres_vsz->SetAxisRange(0,1,"Y");
   h_zres_vsz->Draw();
-
+  h_zres_vsz->Write();
+  
   cz.SaveAs("PV_res_vsz.png");
   cz.SaveAs("PV_res_vsz.eps");
 
@@ -187,10 +192,12 @@ void PlotL1PV(TString name) {
 
   TCanvas c;
   h_eff1->Draw("ep");
+  h_eff1->Write();
   h_eff5->SetMarkerStyle(24);
   h_eff5->SetMarkerColor(2);
   h_eff5->SetLineColor(2);
   h_eff5->Draw("ep,same");
+  h_eff5->Write();
 
   TLegend* l = new TLegend(0.2,0.2,0.5,0.4);
   l->SetFillColor(0);
@@ -203,6 +210,8 @@ void PlotL1PV(TString name) {
 
   c.SaveAs("PV_eff.png");
   c.SaveAs("PV_eff.eps");
+
+  fout->Close();
 
 }
 

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/compareEfficiency.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/compareEfficiency.py
@@ -3,7 +3,7 @@ import os
 import os.path
 
 # Use this for user specific label at the end of the filename
-userLabel = ""
+userLabel = "_KF4ParamsComb"
 
 # Labels for input files
 PUtypes = ["0","140","200"]
@@ -248,5 +248,6 @@ if __name__ == '__main__':
       compareEfficiency("eff_pt_"+ptRange,sample,ptRange,pdg)
       compareEfficiency("eff_eta_"+ptRange,sample,ptRange,pdg)
 
-
+  compareEfficiency("eff_z0_L",'MuonFLATBS','L',13)
+  compareEfficiency("eff_z0_H",'MuonFLATBS','H',13)
 

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/compareEfficiency.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/compareEfficiency.py
@@ -216,16 +216,17 @@ def compareEfficiency(what, sample, ptRange=0, pdgid=0):
   l.Draw()
 
   # Save canvas
-  if not os.path.isdir('OverlayPlots'):
-    os.mkdir('OverlayPlots')
-  outputFileName = "OverlayPlots/{sample}_{what}.pdf".format( sample = sample, what=what )
+  outputDir = 'OverlayPlots{userLabel}'.format(userLabel=userLabel)
+  if not os.path.isdir(outputDir):
+    os.mkdir(outputDir)
+  outputFileName = "{outputDir}/{sample}_{what}.pdf".format( outputDir=outputDir, sample = sample, what=what )
   if sample == 'TTbar':
     if pdgid == 13:
-      outputFileName = "OverlayPlots/{sample}_muons_{what}.pdf".format( sample = sample, what=what )
+      outputFileName = "{outputDir}/{sample}_muons_{what}.pdf".format( outputDir=outputDir, sample = sample, what=what )
     elif pdgid == 1:
-      outputFileName = "OverlayPlots/{sample}_injet_{what}.pdf".format( sample = sample, what=what )
+      outputFileName = "{outputDir}/{sample}_injet_{what}.pdf".format( outputDir=outputDir, sample = sample, what=what )
     elif pdgid == 2:
-      outputFileName = "OverlayPlots/{sample}_injet_highpt_{what}.pdf".format( sample = sample, what=what )
+      outputFileName = "{outputDir}/{sample}_injet_highpt_{what}.pdf".format( outputDir=outputDir, sample = sample, what=what )
   canvas.Print(outputFileName);
 
 if __name__ == '__main__':
@@ -236,7 +237,8 @@ if __name__ == '__main__':
     compareEfficiency("eff_pt_H","TTbar",0,pdg)
     compareEfficiency("eff_eta_L","TTbar",0,pdg)
     compareEfficiency("eff_eta_H","TTbar",0,pdg)
-
+    compareEfficiency("eff_pt","TTbar",0,pdg)
+    compareEfficiency("eff_eta","TTbar",0,pdg)
 
   samplePdg = {
   'Muon' : 13,

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/compareEfficiency.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/compareEfficiency.py
@@ -3,7 +3,7 @@ import os
 import os.path
 
 # Use this for user specific label at the end of the filename
-userLabel = "_KF4ParamsComb"
+userLabel = ""
 
 # Labels for input files
 PUtypes = ["0","140","200"]

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/compareIsolation.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/compareIsolation.py
@@ -3,7 +3,7 @@ import os
 import os.path
 
 # Use this for user specific label at the end of the filename
-userLabel = "_KF4ParamsComb"
+userLabel = ""
 
 # Labels for input files
 PUtypes = ["0","140","200"]

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/comparePV.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/comparePV.py
@@ -1,0 +1,231 @@
+import ROOT as r
+import os
+import os.path
+
+# Use this for user specific label at the end of the filename
+userLabel = "_KF4ParamsComb"
+
+# Labels for input files
+PUtypes = ["0","140","200"]
+ptRangeTypes = {
+0:"",
+'L' : "Pt2to8",
+'H' : "Pt8to100"
+}
+pdgIdTypes = { 0 : "",
+               1 : "injet",
+               2 : "injet_highpt",
+               13 : "pdgid13",
+               11 : "pdgid11",
+               211 : "pdgid211"
+}
+
+def SetPlotStyle():
+  # from ATLAS plot style macro
+  # use plain black on white colors
+  r.gStyle.SetFrameBorderMode(0)
+  r.gStyle.SetFrameFillColor(0)
+  r.gStyle.SetCanvasBorderMode(0)
+  r.gStyle.SetCanvasColor(0)
+  r.gStyle.SetPadBorderMode(0)
+  r.gStyle.SetPadColor(0)
+  r.gStyle.SetStatColor(0)
+  r.gStyle.SetHistLineColor(1)
+
+  r.gStyle.SetPalette(1)
+
+  # set the paper & margin sizes
+  r.gStyle.SetPaperSize(20,26)
+  r.gStyle.SetPadTopMargin(0.05)
+  r.gStyle.SetPadRightMargin(0.05)
+  r.gStyle.SetPadBottomMargin(0.16)
+  r.gStyle.SetPadLeftMargin(0.16)
+
+  # set title offsets (for axis label)
+  r.gStyle.SetTitleXOffset(1.4)
+  r.gStyle.SetTitleYOffset(1.4)
+
+  # use large fonts
+  r.gStyle.SetTextFont(42)
+  r.gStyle.SetTextSize(0.05)
+  r.gStyle.SetLabelFont(42,"x")
+  r.gStyle.SetTitleFont(42,"x")
+  r.gStyle.SetLabelFont(42,"y")
+  r.gStyle.SetTitleFont(42,"y")
+  r.gStyle.SetLabelFont(42,"z")
+  r.gStyle.SetTitleFont(42,"z")
+  r.gStyle.SetLabelSize(0.05,"x")
+  r.gStyle.SetTitleSize(0.05,"x")
+  r.gStyle.SetLabelSize(0.05,"y")
+  r.gStyle.SetTitleSize(0.05,"y")
+  r.gStyle.SetLabelSize(0.05,"z")
+  r.gStyle.SetTitleSize(0.05,"z")
+
+  # use bold lines and markers
+  r.gStyle.SetMarkerStyle(20)
+  r.gStyle.SetMarkerSize(1.2)
+  r.gStyle.SetHistLineWidth(2)
+  r.gStyle.SetLineStyleString(2,"[12 12]")
+
+  # get rid of error bar caps
+  r.gStyle.SetEndErrorSize(0.)
+
+  # do not display any of the standard histogram decorations
+  r.gStyle.SetOptTitle(0)
+  r.gStyle.SetOptStat(0)
+  r.gStyle.SetOptFit(0)
+
+  # put tick marks on top and RHS of plots
+  r.gStyle.SetPadTickX(1)
+  r.gStyle.SetPadTickY(1)
+
+def mySmallText(x, y, color, text):
+  tsize=0.044;
+  l = r.TLatex();
+  l.SetTextSize(tsize); 
+  l.SetNDC();
+  l.SetTextColor(color);
+  l.DrawLatex(x,y,text);
+
+def getAllHistogramsFromFile( what ):
+
+  # Make list of input trees
+  inputFileNames = [];
+  inputFileNameTemplate = "output_L1PV_TTbar_PU{PU}_{trunc}Truncation{userLabel}.root"
+  inputFileNames.append( inputFileNameTemplate.format(PU = PUtypes[0], trunc = 'With', userLabel=userLabel ) )
+  inputFileNames.append( inputFileNameTemplate.format(PU = PUtypes[1], trunc = 'With', userLabel=userLabel ) )
+  inputFileNames.append( inputFileNameTemplate.format(PU = PUtypes[2], trunc = 'With', userLabel=userLabel ) )
+  inputFileNames.append( inputFileNameTemplate.format(PU = PUtypes[0], trunc = 'Without', userLabel=userLabel ) )
+  inputFileNames.append( inputFileNameTemplate.format(PU = PUtypes[1], trunc = 'Without', userLabel=userLabel ) )
+  inputFileNames.append( inputFileNameTemplate.format(PU = PUtypes[2], trunc = 'Without', userLabel=userLabel ) )
+  print inputFileNames
+  # Get trees from files
+  inputFiles=[];
+  for i in range(0,len(inputFileNames)):
+    if os.path.isfile( inputFileNames[i] ):
+      inputFiles.append(r.TFile(inputFileNames[i]))
+    else:
+      inputFiles.append(None)
+  print inputFiles
+  histograms = {
+  'PU0_wt' : getHistogramFromFile(inputFiles[0], what),
+  'PU140_wt' : getHistogramFromFile(inputFiles[1], what),
+  'PU200_wt' : getHistogramFromFile(inputFiles[2], what),
+  'PU0_wot' : getHistogramFromFile(inputFiles[3], what),
+  'PU140_wot' : getHistogramFromFile(inputFiles[4], what),
+  'PU200_wot' : getHistogramFromFile(inputFiles[5], what),
+  }
+
+  return histograms
+
+def getHistogramFromFile(file, histogramName):
+  if file != None and file.GetListOfKeys().Contains(histogramName):
+    h = file.Get(histogramName)
+    h.SetDirectory(0)
+    return h
+  else: return None
+
+def setMarkerAndLineAttributes(h, colour, style, lineStyle=1 ):
+  h.SetLineColor( colour )
+  h.SetMarkerColor( colour )
+  h.SetMarkerStyle( style )
+  h.SetLineStyle( lineStyle )
+
+def drawHistogramWithOption(h,drawOption):
+  h.Draw(drawOption)
+  if not 'same' in drawOption:
+    drawOption +=', same'
+  return drawOption
+
+def setupLegend( histograms, PULabels):
+  legx = 0.25;
+  legy = 0.22;
+  r.gPad.cd()
+  l = r.TLegend(legx,legy,legx+0.3,legy+0.18)
+  l.SetFillColor(0)
+  l.SetFillStyle(0)
+  l.SetLineColor(0)
+  l.SetTextSize(0.04)
+  l.AddEntry(histograms['PU0_wt'], "With truncation", "p")
+  l.AddEntry(histograms['PU0_wot'], "Without truncation", "l")
+  l.AddEntry(None,"","")
+
+  if histograms['PU0_wt'] != None or histograms['PU0_wot'] != None :
+    h = histograms['PU0_wt']
+    if h == None: h = histograms['PU0_wot']
+    l.AddEntry(h,PULabels[0],"lp")
+  if histograms['PU140_wt'] != None or histograms['PU140_wot'] != None :
+    h = histograms['PU140_wt']
+    if h == None: h = histograms['PU140_wot']
+    l.AddEntry(h,PULabels[1],"lp")
+  if histograms['PU200_wt'] != None or histograms['PU200_wot'] != None :
+    h = histograms['PU200_wt']
+    if h == None: h = histograms['PU200_wot']
+    l.AddEntry(h,PULabels[2],"lp")
+  l.SetTextFont(42)
+
+  return l
+
+# ----------------------------------------------------------------------------------------------------------------
+# Main script
+def comparePV(what):
+  
+  SetPlotStyle()
+  # Labels for the plots
+  PULabels = ["<PU>=0", "<PU>=140", "<PU>=200"]
+  ptRangeLabels = ["2 < P_{T} < 8 GeV","P_{T} > 8 GeV"]
+
+  # Get histograms
+  histograms = getAllHistogramsFromFile( what )
+
+  canvas = r.TCanvas()
+
+  # Draw histogram with truncation, as points
+  drawOption='p'
+  if histograms['PU0_wt'] != None:
+    setMarkerAndLineAttributes( histograms['PU0_wt'], 1, 20, 1)
+    drawOption = drawHistogramWithOption( histograms['PU0_wt'], drawOption )
+  if histograms['PU140_wt'] != None :
+    setMarkerAndLineAttributes( histograms['PU140_wt'], 2, 22, 1)
+    drawOption = drawHistogramWithOption( histograms['PU140_wt'], drawOption )
+  if histograms['PU200_wt'] != None:
+    setMarkerAndLineAttributes( histograms['PU200_wt'], 9, 21, 1)
+    drawOption = drawHistogramWithOption (histograms['PU200_wt'], drawOption)
+
+  if 'same' in drawOption:
+    drawOption = 'hist,l,same'
+  else:
+    drawOption = 'hist,l'
+
+  # Draw histograms without truncation, as lines
+  if histograms['PU0_wot'] != None:
+    setMarkerAndLineAttributes( histograms['PU0_wot'], 1, 20, 2)
+    drawOption = drawHistogramWithOption (histograms['PU0_wot'], drawOption )
+  if histograms['PU140_wot'] != None:
+    setMarkerAndLineAttributes( histograms['PU140_wot'], 2, 4, 2)
+    drawOption = drawHistogramWithOption (histograms['PU140_wot'], drawOption )
+  if histograms['PU200_wot'] != None:
+    setMarkerAndLineAttributes( histograms['PU200_wot'], 9, 33, 2)
+    drawOption = drawHistogramWithOption (histograms['PU200_wot'], drawOption )
+  r.gPad.SetGridy();
+
+  # Make the legend
+  l = setupLegend(histograms,PULabels)
+  l.Draw()
+
+  # Save canvas
+  if not os.path.isdir('OverlayPlots'):
+    os.mkdir('OverlayPlots')
+  outputFileName = "OverlayPlots/{what}.pdf".format( what=what )
+  canvas.Print(outputFileName);
+
+if __name__ == '__main__':
+  r.gROOT.SetBatch()
+
+  comparePV("eff1")
+  comparePV("zres_vsz")
+
+
+
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/comparePV.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/comparePV.py
@@ -216,7 +216,7 @@ def comparePV(what):
   # Save canvas
   if not os.path.isdir('OverlayPlots'):
     os.mkdir('OverlayPlots')
-  outputFileName = "OverlayPlots/{what}.pdf".format( what=what )
+  outputFileName = "OverlayPlots/PV_{what}.pdf".format( what=what )
   canvas.Print(outputFileName);
 
 if __name__ == '__main__':

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/comparePV.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/comparePV.py
@@ -3,7 +3,7 @@ import os
 import os.path
 
 # Use this for user specific label at the end of the filename
-userLabel = "_KF4ParamsComb"
+userLabel = ""
 
 # Labels for input files
 PUtypes = ["0","140","200"]

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/compareResolution.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/compareResolution.py
@@ -4,7 +4,7 @@ import os.path
 
 # Use this for user specific label at the end of the filename
 # userLabel = "_globalLinearRegression2"
-userLabel = "_KF4ParamsComb"
+userLabel = ""
 
 # Labels for input files
 PUtypes = ["0","140","200"]

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/compareResolution.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/compareResolution.py
@@ -3,7 +3,8 @@ import os
 import os.path
 
 # Use this for user specific label at the end of the filename
-userLabel = ""
+# userLabel = "_globalLinearRegression2"
+userLabel = "_KF4ParamsComb"
 
 # Labels for input files
 PUtypes = ["0","140","200"]
@@ -91,8 +92,12 @@ def getAllHistogramsFromFile( what, sample, ptRange, pdgid ):
 
   # Make list of input trees
   inputFileNames = [];
-  # inputFileNameTemplate = "output_Hist_{sample}_{PU}{ptRange}{pdg}_{trunc}Truncation{userLabel}.root"
-  inputFileNameTemplate = "output_{sample}{ptRange}_PU{PU}_{trunc}Truncation_{pdg}{userLabel}.root"
+  inputFileNameTemplate = ""
+  if sample == 'TTbar':
+    inputFileNameTemplate = "output_{sample}_PU{PU}_{trunc}Truncation_{pdg}{userLabel}.root"
+  else :
+    inputFileNameTemplate = "output_{sample}{ptRange}_PU{PU}_{trunc}Truncation_{pdg}{userLabel}.root"
+
   inputFileNames.append( inputFileNameTemplate.format(sample = sample, PU = PUtypes[0], ptRange=ptRangeTypes[ptRange], pdg=pdgIdTypes[pdgid], trunc = 'With', userLabel=userLabel ) )
   inputFileNames.append( inputFileNameTemplate.format(sample = sample, PU = PUtypes[1], ptRange=ptRangeTypes[ptRange], pdg=pdgIdTypes[pdgid], trunc = 'With', userLabel=userLabel ) )
   inputFileNames.append( inputFileNameTemplate.format(sample = sample, PU = PUtypes[2], ptRange=ptRangeTypes[ptRange], pdg=pdgIdTypes[pdgid], trunc = 'With', userLabel=userLabel ) )
@@ -148,7 +153,7 @@ def drawHistogramWithOption(h,drawOption):
     drawOption +=', same'
   return drawOption
 
-def setupLegend(sample, histograms, PULabels):
+def setupLegend(sample, histograms68, histograms99, PULabels):
   legx = 0.25;
   legy = 0.3;
   r.gPad.cd()
@@ -157,25 +162,40 @@ def setupLegend(sample, histograms, PULabels):
   l.SetFillStyle(0)
   l.SetLineColor(0)
   l.SetTextSize(0.04)
-  l.AddEntry(histograms['PU0_wt'], "With truncation", "p")
-  l.AddEntry(histograms['PU0_wot'], "Without truncation", "l")
+  l.AddEntry(histograms68['PU0_wt'], "With truncation", "p")
+  l.AddEntry(histograms68['PU0_wot'], "Without truncation", "l")
   l.AddEntry(None,"","")
 
-  if histograms['PU0_wt'] != None or histograms['PU0_wot'] != None :
-    h = histograms['PU0_wt']
-    if h == None: h = histograms['PU0_wot']
+  if histograms68['PU0_wt'] != None or histograms68['PU0_wot'] != None :
+    h = histograms68['PU0_wt']
+    if h == None: h = histograms68['PU0_wot']
     l.AddEntry(h,PULabels[0],"lp")
-  if histograms['PU140_wt'] != None or histograms['PU140_wot'] != None :
-    h = histograms['PU140_wt']
-    if h == None: h = histograms['PU140_wot']
+  if histograms68['PU140_wt'] != None or histograms68['PU140_wot'] != None :
+    h = histograms68['PU140_wt']
+    if h == None: h = histograms68['PU140_wot']
     l.AddEntry(h,PULabels[1],"lp")
-  if histograms['PU200_wt'] != None or histograms['PU200_wot'] != None :
-    h = histograms['PU200_wt']
-    if h == None: h = histograms['PU200_wot']
+  if histograms68['PU200_wt'] != None or histograms68['PU200_wot'] != None :
+    h = histograms68['PU200_wt']
+    if h == None: h = histograms68['PU200_wot']
     l.AddEntry(h,PULabels[2],"lp")
   l.SetTextFont(42)
 
-  return l
+  l1 = r.TLegend(0.65,0.65,0.85,0.85)
+  l1.SetFillStyle(0)
+  l1.SetBorderSize(0)
+  l1.SetTextSize(0.04)
+  if ( histograms68['PU0_wt'] != None ):
+    l1.AddEntry(histograms99['PU0_wt'],"99%","p")
+    l1.AddEntry(histograms68['PU0_wt'],"68%","p")
+  elif ( histograms68['PU140_wt'] != None ):
+    l1.AddEntry(histograms99['PU140_wt'],"99%","p")
+    l1.AddEntry(histograms68['PU140_wt'],"68%","p")
+  elif ( histograms68['PU200_wt'] != None ):
+    l1.AddEntry(histograms99['PU200_wt'],"99%","p")
+    l1.AddEntry(histograms68['PU200_wt'],"68%","p")
+  l1.SetTextFont(42)
+
+  return l, l1
 
 def removeFirstBin( histograms ):
   for name,h in histograms.iteritems():
@@ -246,34 +266,49 @@ def compareResolution(what, sample, ptRange=0, pdgid=0):
     drawOption = drawHistogramWithOption (histograms99['PU200_wot'], drawOption )
 
   # Make the legend
-  l = setupLegend(sample,histograms68,PULabels)
+  l, l1 = setupLegend(sample,histograms68,histograms99,PULabels)
   l.Draw()
-
+  l1.Draw()
   # Save canvas
-  if not os.path.isdir('OverlayPlots'):
-    os.mkdir('OverlayPlots')
-  outputFileName = "OverlayPlots/{sample}_{what}.pdf".format( sample = sample, what=what )
+  outputDir = 'OverlayPlots{userLabel}'.format(userLabel=userLabel)
+  if not os.path.isdir(outputDir):
+    os.mkdir(outputDir)
+  outputFileName = "{outputDir}/{sample}_{what}.pdf".format( outputDir = outputDir, sample = sample, what=what )
   if sample == 'TTbar':
     if pdgid == 13:
-      outputFileName = "OverlayPlots/{sample}_muons_{what}.pdf".format( sample = sample, what=what )
+      outputFileName = "{outputDir}/{sample}_muons_{what}.pdf".format( outputDir = outputDir, sample = sample, what=what )
     elif pdgid == 1:
-      outputFileName = "OverlayPlots/{sample}_injet_{what}.pdf".format( sample = sample, what=what )
+      outputFileName = "{outputDir}/{sample}_injet_{what}.pdf".format( outputDir = outputDir, sample = sample, what=what )
     elif pdgid == 2:
-      outputFileName = "OverlayPlots/{sample}_injet_highpt_{what}.pdf".format( sample = sample, what=what )
+      outputFileName = "{outputDir}/{sample}_injet_highpt_{what}.pdf".format( outputDir = outputDir, sample = sample, what=what )
   canvas.Print(outputFileName);
 
 if __name__ == '__main__':
   r.gROOT.SetBatch()
 
   for pdg in [1,2,13]:
-    compareResolution("resVsEta_phi","TTbar",0,pdg)
-    compareResolution("resVsEta_z0","TTbar",0,pdg)
-    compareResolution("resVsEta_ptRel","TTbar",0,pdg)
-    compareResolution("resVsEta_eta","TTbar",0,pdg)
-    compareResolution("resVsPt2_phi","TTbar",0,pdg)
-    compareResolution("resVsPt2_z0","TTbar",0,pdg)
-    compareResolution("resVsPt2_ptRel","TTbar",0,pdg)
-    compareResolution("resVsPt2_eta","TTbar",0,pdg)
+
+
+    if pdg == 13:
+      for ptRange in ['L','H']:
+        compareResolution("resVsEta_phi_"+ptRange,"TTbar",ptRange,pdg)
+        compareResolution("resVsEta_z0_"+ptRange,"TTbar",ptRange,pdg)
+        compareResolution("resVsEta_ptRel_"+ptRange,"TTbar",ptRange,pdg)
+        compareResolution("resVsEta_eta_"+ptRange,"TTbar",ptRange,pdg)
+
+        compareResolution("resVsPt2_phi","TTbar",ptRange,pdg)
+        compareResolution("resVsPt2_z0","TTbar",ptRange,pdg)
+        compareResolution("resVsPt2_ptRel","TTbar",ptRange,pdg)
+        compareResolution("resVsPt2_eta","TTbar",ptRange,pdg)
+    else:
+      compareResolution("resVsEta_phi","TTbar",0,pdg)
+      compareResolution("resVsEta_z0","TTbar",0,pdg)
+      compareResolution("resVsEta_ptRel","TTbar",0,pdg)
+      compareResolution("resVsEta_eta","TTbar",0,pdg)
+      compareResolution("resVsPt2_phi","TTbar",0,pdg)
+      compareResolution("resVsPt2_z0","TTbar",0,pdg)
+      compareResolution("resVsPt2_ptRel","TTbar",0,pdg)
+      compareResolution("resVsPt2_eta","TTbar",0,pdg)
 
   samplePdg = {
     'Muon' : 13,

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/templateSlidesConfig.json
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/templateSlidesConfig.json
@@ -227,10 +227,30 @@
         },
 
         {
+            "title": "Wide BS",
+            "toptext": "Efficiency vs z0: pT 2-8 GeV, pT 8-100 GeV",
+            "plots": [
+                ["../OverlayPlots/MuonFLATBS_eff_z0_L.pdf",     ""],
+                ["../OverlayPlots/MuonFLATBS_eff_z0_H.pdf",     ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
             "title": "Track Isolation",
             "toptext": "Prompt / non-prompt muons in ttbar + PU",
             "plots": [
                 ["../OverlayPlots/Isolation.pdf",     ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Vertex Finding",
+            "toptext": "Efficiency and resolution in ttbar + PU.  Cut at $\\Delta$(L1, PV) $<$ 1mm",
+            "plots": [
+                ["../OverlayPlots/PV_eff1.pdf",     ""],
+                ["../OverlayPlots/PV_zres_vsz.pdf",     ""]
             ],
             "bottomtext": ""
         },

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/templateSlidesConfig.json
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/templateSlidesConfig.json
@@ -204,7 +204,31 @@
 
         {
             "title": "Baseline Metrics: muon in ttbar",
-            "toptext": "Resolution vs pT 2-8 GeV",
+            "toptext": "Resolution vs pT, 2-8 GeV",
+            "plots": [
+                ["../OverlayPlots/TTbar_muons_resVsPt2_eta_L.pdf",     ""],
+                ["../OverlayPlots/TTbar_muons_resVsPt2_phi_L.pdf",     ""],
+                ["../OverlayPlots/TTbar_muons_resVsPt2_ptRel_L.pdf",   ""],
+                ["../OverlayPlots/TTbar_muons_resVsPt2_z0_L.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: muon in ttbar",
+            "toptext": "Resolution vs eta, 2-8 GeV",
+            "plots": [
+                ["../OverlayPlots/TTbar_muons_resVsEta_eta_L.pdf",     ""],
+                ["../OverlayPlots/TTbar_muons_resVsEta_phi_L.pdf",     ""],
+                ["../OverlayPlots/TTbar_muons_resVsEta_ptRel_L.pdf",   ""],
+                ["../OverlayPlots/TTbar_muons_resVsEta_z0_L.pdf",      ""]
+            ],
+            "bottomtext": ""
+        },
+
+        {
+            "title": "Baseline Metrics: muon in ttbar",
+            "toptext": "Resolution vs pT, 8-100 GeV",
             "plots": [
                 ["../OverlayPlots/TTbar_muons_resVsPt2_eta.pdf",     ""],
                 ["../OverlayPlots/TTbar_muons_resVsPt2_phi.pdf",     ""],
@@ -216,12 +240,12 @@
 
         {
             "title": "Baseline Metrics: muon in ttbar",
-            "toptext": "Resolution vs eta, pT 8-100 GeV",
+            "toptext": "Resolution vs eta, 8-100 GeV",
             "plots": [
-                ["../OverlayPlots/TTbar_muons_resVsEta_eta.pdf",     ""],
-                ["../OverlayPlots/TTbar_muons_resVsEta_phi.pdf",     ""],
-                ["../OverlayPlots/TTbar_muons_resVsEta_ptRel.pdf",   ""],
-                ["../OverlayPlots/TTbar_muons_resVsEta_z0.pdf",      ""]
+                ["../OverlayPlots/TTbar_muons_resVsEta_eta_H.pdf",     ""],
+                ["../OverlayPlots/TTbar_muons_resVsEta_phi_H.pdf",     ""],
+                ["../OverlayPlots/TTbar_muons_resVsEta_ptRel_H.pdf",   ""],
+                ["../OverlayPlots/TTbar_muons_resVsEta_z0_H.pdf",      ""]
             ],
             "bottomtext": ""
         },
@@ -269,7 +293,7 @@
 
         {
             "title": "Tracking in Jets",
-            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT less than 30 GeV",
+            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT above 30 GeV",
             "plots": [
                 ["../OverlayPlots/TTbar_injet_resVsPt2_eta.pdf",     ""],
                 ["../OverlayPlots/TTbar_injet_resVsPt2_phi.pdf",     ""],
@@ -281,7 +305,7 @@
 
         {
             "title": "Tracking in Jets",
-            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT less than 30 GeV",
+            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT above 30 GeV",
             "plots": [
                 ["../OverlayPlots/TTbar_injet_resVsEta_eta.pdf",     ""],
                 ["../OverlayPlots/TTbar_injet_resVsEta_phi.pdf",     ""],
@@ -293,7 +317,7 @@
 
         {
             "title": "Tracking in Jets",
-            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT above 30 GeV",
+            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT above 100 GeV",
             "plots": [
                 ["../OverlayPlots/TTbar_injet_highpt_resVsPt2_eta.pdf",     ""],
                 ["../OverlayPlots/TTbar_injet_highpt_resVsPt2_phi.pdf",     ""],
@@ -305,7 +329,7 @@
 
         {
             "title": "Tracking in Jets",
-            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT above 30 GeV",
+            "toptext": "Resolution of all tracks with pT above 3 GeV in ttbar jets with pT above 100 GeV",
             "plots": [
                 ["../OverlayPlots/TTbar_injet_highpt_resVsEta_eta.pdf",     ""],
                 ["../OverlayPlots/TTbar_injet_highpt_resVsEta_phi.pdf",     ""],


### PR DESCRIPTION
- Add plots of efficiency vs z0 for low and high pt tracks.  Used for wide BS template slides.
- Add script for producing overlay of PV finding plots
- Use separate resolution plots for low/high pt muons in ttbar
- Some typos in template slide text